### PR TITLE
Add ability to fetch active sprints for a board

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -2,19 +2,27 @@ package config
 
 import (
 	"fmt"
+	"io/ioutil"
+
 	"github.com/ghodss/yaml"
 	"gopkg.in/errgo.v2/errors"
-	"io/ioutil"
 )
 
 type Config struct {
-	Spreadsheets []Spreadsheet `json:"spreadsheets"`
+	Spreadsheets       []Spreadsheet      `json:"spreadsheets"`
+	ActiveSprintsSheet ActiveSprintsSheet `json:"activeSprintsSheet,omitempty"`
 }
 
 type Spreadsheet struct {
-	Url         string   `json:"url"`
-	SheetName   string   `json:"sheetName"`
+	Url        string `json:"url"`
+	SheetName  string `json:"sheetName"`
 	JiraFilter string `json:"jiraFilter"`
+}
+
+type ActiveSprintsSheet struct {
+	Url          string `json:"url"`
+	SheetName    string `json:"sheetName"`
+	JiraEndpoint string `json:"jiraEndpoint"`
 }
 
 func ReadConfig(path string) (*Config, error) {

--- a/pkg/importer/importer.go
+++ b/pkg/importer/importer.go
@@ -2,16 +2,18 @@ package importer
 
 import (
 	"context"
+	"encoding/json"
+	"log"
+
 	"github.com/pmuir/jira2sheets/pkg/config"
 	"gopkg.in/errgo.v2/errors"
-	"log"
 )
 
 type Importer struct {
-	Cfg     *config.Config
-	JiraPat string
+	Cfg                   *config.Config
+	JiraPat               string
 	GoogleCredentialsJson string
-	Verbose bool
+	Verbose               bool
 }
 
 type JiraCsvUrlParams struct {
@@ -51,6 +53,62 @@ func (i *Importer) Run() error {
 		}
 		if i.Verbose {
 			log.Printf("finished processing %s %s", spreadsheet.Url, spreadsheet.SheetName)
+		}
+	}
+
+	if i.Cfg.ActiveSprintsSheet.Url != "" && i.Cfg.ActiveSprintsSheet.SheetName != "" && i.Cfg.ActiveSprintsSheet.JiraEndpoint != "" {
+
+		if i.Verbose {
+			log.Printf("fetching active sprints using endopint: %s", i.Cfg.ActiveSprintsSheet.JiraEndpoint)
+		}
+		data, err := i.fetchApiGet(i.Cfg.ActiveSprintsSheet.JiraEndpoint)
+		if err != nil {
+			return errors.Wrap(err)
+		}
+
+		if len(data) > 0 {
+			type Value struct {
+				Id            int64  `json:"id"`
+				Name          string `json:"name"`
+				OriginBoardId int64  `json:"originBoardId"`
+				StartDate     string `json:"startDate"`
+				EndDate       string `json:"endDate"`
+			}
+
+			type Response struct {
+				Values []Value `json:"values"`
+			}
+
+			var response Response
+			json.Unmarshal([]byte(data), &response)
+
+			if i.Verbose {
+				log.Printf("active sprints: %+v", response.Values)
+			}
+
+			names := make([][]interface{}, len(response.Values))
+			for i, v := range response.Values {
+				board := make([]interface{}, 5)
+				board[0] = v.Id
+				board[1] = v.Name
+				board[2] = v.OriginBoardId
+				board[3] = v.StartDate
+				board[4] = v.EndDate
+
+				names[i] = board
+			}
+
+			headers := make([]interface{}, 5)
+			headers[0] = "Sprint Id"
+			headers[1] = "Name"
+			headers[2] = "OriginBoardId"
+			headers[3] = "Start Date"
+			headers[4] = "End Date"
+
+			err := i.putCsvsToSheet(ctx, i.Cfg.ActiveSprintsSheet.Url, i.Cfg.ActiveSprintsSheet.SheetName, headers, names)
+			if err != nil {
+				return errors.Wrap(err)
+			}
 		}
 	}
 	return nil

--- a/samples/jira2sheets.yml
+++ b/samples/jira2sheets.yml
@@ -2,3 +2,7 @@ spreadsheets:
   - url: https://docs.google.com/spreadsheets/d/1C9bGvXp0jMr0sfY2w9_OIfHd70YBf-Y8Sln02v7dFo0/edit#gid=0
     sheetName: "Test Sheet"
     jiraFilter: https://issues.redhat.com/issues/?filter=12391028
+activeSprintsSheet:
+  url: https://docs.google.com/spreadsheets/d/1C9bGvXp0jMr0sfY2w9_OIfHd70YBf-Y8Sln02v7dFo0/edit#gid=0
+  sheetName: "Active Sprints"
+  jiraEndpoint: https://issues.redhat.com/rest/agile/1.0/board/8806/sprint?state=active


### PR DESCRIPTION
This uses the Jira REST API rather than the search interface, so a new
section was needed in the config file.

The hope is that we'll be able to use the results by finding the
sprint with the desired "originBoardId" matching the original query,
and stripping out the part we want (the current sprint number), in
dynamic sheets.